### PR TITLE
Fix Cloudflare deploy by adding build step and deferring OpenAI init

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,6 +4,7 @@ import robotsTxt from "astro-robots-txt";
 
 export default defineConfig({
   integrations: [tailwind(), robotsTxt()],
-  // QUITA base y site para Pages en raíz
-  // output por defecto ya es "static" en tu build
+  adapter: cloudflare({
+    platformProxy: { enabled: true }, // habilita runtime CF en `astro dev`
+  }),
 });

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "build": "astro check && astro build",
     "preview": "astro preview",
     "astro": "astro"
-    
   },
   "dependencies": {
     "@astrojs/check": "0.5.6",
@@ -21,5 +20,8 @@
     "resend": "^4.5.1",
     "tailwindcss": "3.4.1",
     "typescript": "5.3.3"
+  },
+  "devDependencies": {
+    "wrangler": "^4.33.1"
   }
 }

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,2 +1,9 @@
 /// <reference path="../.astro/types.d.ts" />
 /// <reference types="astro/client" />
+type Runtime = import("@astrojs/cloudflare").Runtime<{
+  OPENAI_API_KEY: string;
+  OPENAI_BASE_URL?: string; // si usas AI Gateway
+}>;
+declare namespace App {
+  interface Locals extends Runtime {}
+}

--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -3,10 +3,6 @@ import type { APIRoute } from "astro";
 import OpenAI from "openai";
 import cvData from "@/data/cv_data.json";
 
-const openai = new OpenAI({
-  apiKey: import.meta.env.OPENAI_API_KEY,
-});
-
 // Function to summarize CV data to keep the prompt concise
 function getCvContextPrompt(data: any): string {
   const {
@@ -141,6 +137,19 @@ function getCvContextPrompt(data: any): string {
 
 export const POST: APIRoute = async ({ request }) => {
   try {
+    const apiKey = import.meta.env.OPENAI_API_KEY;
+    if (!apiKey) {
+      return new Response(
+        JSON.stringify({ error: "OPENAI_API_KEY is not set" }),
+        {
+          status: 500,
+          headers: { "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    const openai = new OpenAI({ apiKey });
+
     const body = await request.json();
     const userMessage = body.message;
 

--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -14,15 +14,12 @@ function getCvContextPrompt(data: any): string {
     academic_formation,
     certifications,
     languages,
-    chatbot_info,
-    footer_info,
   } = data;
 
   // Bloque inicial con 'hook' persuasivo orientado a QA Automation
   let context = `Eres ${basic_info.name}. Tu misión es venderte de forma contundente, profesional y atractiva para que te contraten como QA Automation Engineer. Basa TODAS tus respuestas ÚNICAMENTE en la información de tu CV. NO INVENTES ni hagas suposiciones. Habla siempre en primera persona con confianza. Sé breve y directo.\n\n`;
 
   // Hook inicial: logros relevantes en CI/CD y automatización
-  console.log(`${professional_experience[0]?.company}`);
   context += `=== Presentación Rápida ===\n`;
   context += `- “Ingeniero Informático apasionado en Machine Learning & AI que en mi rol en ${professional_experience[0]?.company} diseñó e implementó pipelines de CI/CD en Google Cloud Platform usando FastAPI, optimizando procesos de entrega y asegurando calidad continua desde el primer día.”\n\n`;
 
@@ -188,7 +185,6 @@ export const POST: APIRoute = async ({ request }) => {
         }
       },
       cancel() {
-        console.log("Stream cancelled by client.");
       },
     });
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,10 +1,5 @@
 {
   "name": "mi-portfolio",
   "compatibility_date": "2025-08-29",
-  "assets": {
-    "directory": "./dist"
-  },
-  "build": {
-    "command": "bun run build"
-  }
+  "pages_build_output_dir": "./dist"
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -3,5 +3,8 @@
   "compatibility_date": "2025-08-29",
   "assets": {
     "directory": "./dist"
+  },
+  "build": {
+    "command": "bun run build"
   }
 }


### PR DESCRIPTION
## Summary
- add build command to `wrangler.jsonc` so Cloudflare Pages builds before deploy
- instantiate OpenAI client inside POST handler with API key check to avoid build-time failures

## Testing
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1fa7552148324adb3bc0fa58dcbc4