### PR TITLE
Improve chat Markdown rendering and code block UX

### DIFF
--- a/src/components/ui/LocalChat.astro
+++ b/src/components/ui/LocalChat.astro
@@ -319,6 +319,167 @@ const cvContext = JSON.stringify(cvData);
         animation-delay: 0.14s;
     }
 
+    /* Markdown rendering */
+    .chat-markdown {
+        word-wrap: break-word;
+        overflow-wrap: break-word;
+    }
+    .chat-markdown p {
+        margin: 0.4rem 0;
+        line-height: 1.55;
+    }
+    .chat-markdown p + p {
+        margin-top: 0.6rem;
+    }
+    .chat-markdown h1,
+    .chat-markdown h2,
+    .chat-markdown h3,
+    .chat-markdown h4,
+    .chat-markdown h5,
+    .chat-markdown h6 {
+        font-weight: 700;
+        line-height: 1.25;
+        color: inherit;
+        margin: 0.7rem 0 0.35rem 0;
+    }
+    .chat-markdown h1 {
+        font-size: 1.05rem;
+        padding-bottom: 0.4rem;
+        border-bottom: 2px solid rgba(99, 102, 241, 0.25);
+    }
+    .chat-markdown h2 {
+        font-size: 0.95rem;
+        padding-bottom: 0.25rem;
+        border-bottom: 1px solid rgba(99, 102, 241, 0.15);
+    }
+    .chat-markdown h3 {
+        font-size: 0.88rem;
+    }
+    .chat-markdown h4 {
+        font-size: 0.85rem;
+    }
+    .chat-markdown ul,
+    .chat-markdown ol {
+        margin: 0.55rem 0;
+        padding-left: 1.4rem;
+    }
+    .chat-markdown ul {
+        list-style: none;
+    }
+    .chat-markdown ul > li {
+        position: relative;
+        padding-left: 0.6rem;
+    }
+    .chat-markdown ul > li::before {
+        content: "◆";
+        position: absolute;
+        left: -0.6rem;
+        color: #6366f1;
+        font-size: 0.65em;
+        top: 0.35em;
+    }
+    .dark .chat-markdown ul > li::before {
+        color: #818cf8;
+    }
+    .chat-markdown ol {
+        list-style: decimal;
+    }
+    .chat-markdown ol > li {
+        padding-left: 0.4rem;
+    }
+    .chat-markdown li + li {
+        margin-top: 0.3rem;
+    }
+    .chat-markdown li {
+        line-height: 1.5;
+    }
+    .chat-markdown blockquote {
+        margin: 0.55rem 0;
+        border-left: 3px solid #6366f1;
+        padding-left: 0.9rem;
+        padding-right: 0.5rem;
+        padding-top: 0.3rem;
+        padding-bottom: 0.3rem;
+        background: rgba(99, 102, 241, 0.08);
+        border-radius: 0.35rem;
+        font-style: italic;
+        opacity: 0.95;
+    }
+    .dark .chat-markdown blockquote {
+        border-left-color: #818cf8;
+        background: rgba(129, 140, 248, 0.12);
+    }
+    .chat-markdown a {
+        color: #4f46e5;
+        text-decoration: underline;
+        text-underline-offset: 2px;
+        word-break: break-word;
+        font-weight: 500;
+        transition: opacity 0.2s;
+    }
+    .chat-markdown a:hover {
+        opacity: 0.8;
+    }
+    .dark .chat-markdown a {
+        color: #818cf8;
+    }
+    .chat-markdown code {
+        font-family:
+            ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+            "Liberation Mono", "Courier New", monospace;
+        font-size: 0.82em;
+        background: rgba(99, 102, 241, 0.16);
+        color: #5b21b6;
+        padding: 0.1rem 0.4rem;
+        border-radius: 0.35rem;
+        border: 0.5px solid rgba(99, 102, 241, 0.2);
+    }
+    .dark .chat-markdown code {
+        background: rgba(129, 140, 248, 0.15);
+        color: #d8d8e8;
+    }
+    .chat-markdown pre {
+        margin: 0.65rem 0;
+        padding: 0.9rem;
+        border-radius: 0.65rem;
+        background: #f8fafc;
+        border: 2px solid #6366f1;
+        overflow-x: auto;
+        line-height: 1.5;
+    }
+    .dark .chat-markdown pre {
+        background: #1e293b;
+        border: 2px solid #818cf8;
+    }
+    .chat-markdown pre code {
+        background: transparent;
+        padding: 0;
+        border: 0;
+        border-radius: 0;
+        display: block;
+        font-size: 0.8rem;
+        color: inherit;
+    }
+    .dark .chat-markdown pre code {
+        color: #e2e8f0;
+    }
+    .chat-markdown hr {
+        border: 0;
+        border-top: 1.5px solid rgba(99, 102, 241, 0.2);
+        margin: 0.75rem 0;
+    }
+    .dark .chat-markdown hr {
+        border-top-color: rgba(129, 140, 248, 0.25);
+    }
+    .chat-markdown strong {
+        font-weight: 700;
+        color: inherit;
+    }
+    .chat-markdown em {
+        font-style: italic;
+        color: inherit;
+    }
+
     /* Scroll highlight pulse */
     .section-highlight-pulse {
         animation: sectionPulse 1.8s ease-out;
@@ -343,7 +504,6 @@ const cvContext = JSON.stringify(cvData);
         ACTION_SETS,
         SECTION_ANCHORS,
         MODEL_SIZES,
-        MODELS,
         getModelConfig,
     } from "../../utils/local-chat/constants";
     import {
@@ -357,6 +517,7 @@ const cvContext = JSON.stringify(cvData);
         appendUserMessage,
         appendBotMessage,
         renderActionCards,
+        renderChatMarkdown,
     } from "../../utils/local-chat/dom-utils";
 
     env.allowLocalModels = false;
@@ -577,9 +738,7 @@ const cvContext = JSON.stringify(cvData);
 
                     const visible = stripThinkingTags(rawReply);
                     if (!insideThink && visible) {
-                        botBubble.innerHTML = visible
-                            .replace(/\n\n/g, "</p><p class='mt-2'>")
-                            .replace(/\n/g, "<br>");
+                        botBubble.innerHTML = renderChatMarkdown(visible);
                         messagesContainer.scrollTop =
                             messagesContainer.scrollHeight;
                     }
@@ -595,9 +754,7 @@ const cvContext = JSON.stringify(cvData);
 
             const finalText = stripThinkingTags(rawReply).trim();
             botBubble.classList.remove("stream-cursor");
-            botBubble.innerHTML = finalText
-                .replace(/\n\n/g, "</p><p class='mt-2'>")
-                .replace(/\n/g, "<br>");
+            botBubble.innerHTML = renderChatMarkdown(finalText);
 
             historyTracker.push({
                 role: "assistant",

--- a/src/utils/local-chat/ai-logic.ts
+++ b/src/utils/local-chat/ai-logic.ts
@@ -88,7 +88,7 @@ export async function classifyIntent(
 }
 
 export function buildSystemPrompt(cvInfo: string): string {
-    return `Eres el asistente virtual oficial de Carlos Hernández Martínez. 
+    return `Eres el asistente virtual oficial de Carlos Hernández Martínez.
 Tu objetivo es responder de forma precisa y profesional a preguntas sobre su trayectoria basándote EXCLUSIVAMENTE en su CV.
 
 INFORMACIÓN DEL CV:
@@ -99,6 +99,9 @@ REGLAS DE ORO:
 2. Referencia: Si preguntan por experiencia, consulta "professional_experience". Si preguntan por estudios, "academic_formation".
 3. Actualidad: Carlos es QA Backend Developer en Mercadona IT actualmente.
 4. Identidad: Responde en tercera persona (ej: "Carlos posee...", "Según su perfil...").
-5. Brevedad: Máximo 2 frases por respuesta.
-6. Honestidad: Si algo NO está en el CV, di: "Esa información no consta en el CV de Carlos".`;
+5. Formato: Responde SIEMPRE en Markdown limpio y legible.
+6. Estilo Markdown: Usa listas con viñetas para enumeraciones, **negrita** para datos clave y \`inline code\` solo para tecnologías/herramientas cuando aporte claridad.
+7. Brevedad: Máximo 2 frases o 3 bullets cortos por respuesta.
+8. Bloques de código: SOLO si el usuario pide código o comandos explícitamente. Formato: encapsular en triple backtick (\`\`\`lenguaje) seguido del código y cierre con \`\`\`. Ejemplo: \`\`\`javascript\\nconst x = 1;\\n\`\`\`
+9. Honestidad: Si algo NO está en el CV, di: "Esa información no consta en el CV de Carlos".`;
 }

--- a/src/utils/local-chat/dom-utils.ts
+++ b/src/utils/local-chat/dom-utils.ts
@@ -1,4 +1,239 @@
-import { SECTION_ANCHORS, ACTION_SETS } from "./constants";
+import { ACTION_SETS } from "./constants";
+
+function escapeHtml(text: string): string {
+    return text
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;");
+}
+
+function sanitizeUrl(rawUrl: string): string {
+    const url = rawUrl.trim();
+    if (/^(https?:\/\/|mailto:|tel:|#)/i.test(url)) {
+        return escapeHtml(url);
+    }
+    return "#";
+}
+
+function renderInlineMarkdown(text: string): string {
+    const escaped = escapeHtml(text);
+    const codeSnippets: string[] = [];
+    const withCodeTokens = escaped.replace(/`([^`]+)`/g, (_, code: string) => {
+        const token = `__INLINE_CODE_${codeSnippets.length}__`;
+        codeSnippets.push(`<code>${code}</code>`);
+        return token;
+    });
+
+    const withLinks = withCodeTokens.replace(
+        /\[([^\]]+)\]\(([^)]+)\)/g,
+        (_, label: string, href: string) =>
+            `<a href="${sanitizeUrl(href)}" target="_blank" rel="noopener noreferrer">${label}</a>`,
+    );
+    const withBold = withLinks.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
+    const withItalic = withBold.replace(/(^|[^\*])\*(.+?)\*/g, "$1<em>$2</em>");
+
+    return withItalic.replace(
+        /__INLINE_CODE_(\d+)__/g,
+        (_, index: string) => codeSnippets[Number(index)] ?? "",
+    );
+}
+
+function isLikelyProseLine(line: string): boolean {
+    const trimmed = line.trim();
+    if (!trimmed) return false;
+    if (/^#{1,6}\s/.test(trimmed)) return false;
+    if (/^[-*+]\s/.test(trimmed)) return false;
+    if (/^\d+\.\s/.test(trimmed)) return false;
+    if (
+        trimmed.includes("{") ||
+        trimmed.includes("}") ||
+        trimmed.includes(";") ||
+        trimmed.includes("=>")
+    ) {
+        return false;
+    }
+
+    const words = trimmed.split(/\s+/);
+    if (words.length < 6) return false;
+    const hasSentencePunctuation = /[.!?]$/.test(trimmed);
+    const hasLetters = /[a-záéíóúñ]/i.test(trimmed);
+    const hasFewCodeChars = !/[()[\]=]/.test(trimmed);
+    return hasLetters && hasFewCodeChars && hasSentencePunctuation;
+}
+
+function splitUnclosedCodeBlock(
+    codeLines: string[],
+): { code: string; proseTail: string } {
+    let splitIndex = codeLines.length;
+    for (let i = codeLines.length - 1; i >= 0; i -= 1) {
+        if (isLikelyProseLine(codeLines[i])) {
+            splitIndex = i;
+        } else {
+            break;
+        }
+    }
+
+    return {
+        code: codeLines.slice(0, splitIndex).join("\n").trimEnd(),
+        proseTail: codeLines.slice(splitIndex).join("\n").trim(),
+    };
+}
+
+export function renderChatMarkdown(text: string): string {
+    const normalizedText = text.replace(/\r\n/g, "\n");
+    const markdownFence = normalizedText.match(
+        /^```(?:markdown|md)\s*\n([\s\S]*?)\n?```$/i,
+    );
+    const safeText = markdownFence ? markdownFence[1] : normalizedText;
+    const lines = safeText.split("\n");
+    const html: string[] = [];
+    let inCodeBlock = false;
+    let codeBlockLines: string[] = [];
+    let listMode: "ul" | "ol" | null = null;
+    let paragraphLines: string[] = [];
+    let quoteLines: string[] = [];
+
+    const pushCodeBlock = (code: string) => {
+        html.push(`<pre><code>${escapeHtml(code)}</code></pre>`);
+    };
+
+    const flushParagraph = () => {
+        if (!paragraphLines.length) return;
+        html.push(`<p>${renderInlineMarkdown(paragraphLines.join(" "))}</p>`);
+        paragraphLines = [];
+    };
+
+    const flushList = () => {
+        if (!listMode) return;
+        html.push(`</${listMode}>`);
+        listMode = null;
+    };
+
+    const flushQuote = () => {
+        if (!quoteLines.length) return;
+        const content = quoteLines.map((line) => renderInlineMarkdown(line));
+        html.push(`<blockquote><p>${content.join("<br>")}</p></blockquote>`);
+        quoteLines = [];
+    };
+
+    for (const line of lines) {
+        const trimmed = line.trim();
+
+        const singleLineFenceMatch = trimmed.match(
+            /^```(?:[a-zA-Z0-9_\-+#]*)\s*([\s\S]*?)\s*```$/,
+        );
+        if (singleLineFenceMatch) {
+            flushParagraph();
+            flushQuote();
+            flushList();
+            pushCodeBlock(singleLineFenceMatch[1].trim());
+            continue;
+        }
+
+        if (trimmed.startsWith("```")) {
+            flushParagraph();
+            flushQuote();
+            flushList();
+            if (!inCodeBlock) {
+                codeBlockLines = [];
+                inCodeBlock = true;
+            } else {
+                const codeContent = codeBlockLines
+                    .join("\n")
+                    .trim();
+                if (codeContent) {
+                    pushCodeBlock(codeContent);
+                }
+                codeBlockLines = [];
+                inCodeBlock = false;
+            }
+            continue;
+        }
+
+        if (inCodeBlock) {
+            codeBlockLines.push(line);
+            continue;
+        }
+
+        if (!trimmed) {
+            flushParagraph();
+            flushQuote();
+            flushList();
+            continue;
+        }
+
+        const headingMatch = trimmed.match(/^(#{1,6})\s+(.+)$/);
+        if (headingMatch) {
+            flushParagraph();
+            flushQuote();
+            flushList();
+            const level = headingMatch[1].length;
+            const value = renderInlineMarkdown(headingMatch[2]);
+            html.push(`<h${level}>${value}</h${level}>`);
+            continue;
+        }
+
+        if (/^(-{3,}|\*{3,}|_{3,})$/.test(trimmed)) {
+            flushParagraph();
+            flushQuote();
+            flushList();
+            html.push("<hr>");
+            continue;
+        }
+
+        const quoteMatch = trimmed.match(/^>\s?(.*)$/);
+        if (quoteMatch) {
+            flushParagraph();
+            flushList();
+            quoteLines.push(quoteMatch[1]);
+            continue;
+        }
+        flushQuote();
+
+        const unorderedMatch = trimmed.match(/^[-*+]\s+(.+)$/);
+        if (unorderedMatch) {
+            flushParagraph();
+            if (listMode !== "ul") {
+                flushList();
+                listMode = "ul";
+                html.push("<ul>");
+            }
+            html.push(`<li>${renderInlineMarkdown(unorderedMatch[1])}</li>`);
+            continue;
+        }
+
+        const orderedMatch = trimmed.match(/^\d+\.\s+(.+)$/);
+        if (orderedMatch) {
+            flushParagraph();
+            if (listMode !== "ol") {
+                flushList();
+                listMode = "ol";
+                html.push("<ol>");
+            }
+            html.push(`<li>${renderInlineMarkdown(orderedMatch[1])}</li>`);
+            continue;
+        }
+
+        flushList();
+        paragraphLines.push(trimmed);
+    }
+
+    flushParagraph();
+    flushQuote();
+    flushList();
+
+    if (inCodeBlock) {
+        const { code, proseTail } = splitUnclosedCodeBlock(codeBlockLines);
+        if (code) {
+            pushCodeBlock(code);
+        }
+        if (proseTail) {
+            html.push(`<p>${renderInlineMarkdown(proseTail)}</p>`);
+        }
+    }
+
+    return `<div class="chat-markdown">${html.join("")}</div>`;
+}
 
 export function scrollToSection(selectorList: string) {
     const selectors = selectorList.split(",");
@@ -68,7 +303,7 @@ export function appendBotMessage(container: HTMLElement, text: string): { bubble
             <span class="w-1.5 h-1.5 rounded-full bg-indigo-400 animate-bounce" style="animation-delay:300ms"></span>
            </span>`;
     } else {
-        bubble.innerHTML = text.replace(/\n\n/g, "</p><p class='mt-2'>").replace(/\n/g, "<br>");
+        bubble.innerHTML = renderChatMarkdown(text);
     }
 
     wrapper.appendChild(document.createRange().createContextualFragment(avatarHTML()));

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -7,5 +7,8 @@
       "binding": "FINANZAS_KV",
       "id": "1e0c3c3c75b746b3abb467c263b51c55"
     }
-  ]
+  ],
+  "vars": {
+    "FINANZAS_ALLOWED_EMAILS": "carlos.cbm32@gmail.com"
+  }
 }


### PR DESCRIPTION
### Summary
- Add safer Markdown rendering for chat responses, including headings, lists, links, quotes, and inline code
- Improve code block handling for fenced content and malformed/unclosed fences to avoid rendering entire replies as code
- Update chat styles so code blocks are visually distinct and easier to read in both light and dark themes
- Update assistant prompt guidance to encourage cleaner Markdown-formatted responses

### Testing
- `npm run build`