### PR TITLE
feat: add downloadable CV to portfolio

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro check && astro build",
+    "generate:cv": "python3 scripts/generate_cv_pdf.py",
     "preview": "astro preview",
     "astro": "astro"
   },

--- a/public/carlos-hernandez-martinez-cv.pdf
+++ b/public/carlos-hernandez-martinez-cv.pdf
@@ -1,0 +1,154 @@
+%PDF-1.4
+%âãÏÓ
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [6 0 R 7 0 R] /Count 2 >>
+endobj
+3 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding >>
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding >>
+endobj
+6 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595.28 841.89] /Resources << /Font << /F1 3 0 R /F2 4 0 R /F3 5 0 R >> >> /Contents 8 0 R >>
+endobj
+7 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595.28 841.89] /Resources << /Font << /F1 3 0 R /F2 4 0 R /F3 5 0 R >> >> /Contents 9 0 R >>
+endobj
+8 0 obj
+<< /Length 6485 >>
+stream
+q 0.080 0.160 0.270 rg 0.00 826.89 595.28 15.00 re f Q
+BT /F2 24.00 Tf 0.080 0.160 0.270 rg 1 0 0 1 48.00 786.00 Tm (Carlos Hernández Martínez) Tj ET
+BT /F2 11.50 Tf 0.060 0.490 0.520 rg 1 0 0 1 48.00 758.00 Tm (QA & AI Engineer | Backend Developer) Tj ET
+BT /F3 9.30 Tf 0.350 0.390 0.440 rg 1 0 0 1 48.00 739.00 Tm (Bridging the gap between AI innovation and software reliability.) Tj ET
+BT /F1 8.25 Tf 0.350 0.390 0.440 rg 1 0 0 1 48.00 716.00 Tm (chermar.pro@gmail.com | carlos.cbm32@gmail.com) Tj ET
+BT /F1 8.25 Tf 0.350 0.390 0.440 rg 1 0 0 1 48.00 704.00 Tm (LinkedIn: https://linkedin.com/in/carl0shdez | GitHub: https://github.com/Tempus23 | Valencia, Spain) Tj ET
+q 1.00 w 0.880 0.900 0.920 RG 48.00 681.00 m 547.28 681.00 l S Q
+BT /F2 10.00 Tf 0.080 0.160 0.270 rg 1 0 0 1 48.00 641.00 Tm (SUMMARY) Tj ET
+q 1.35 w 0.060 0.490 0.520 RG 48.00 633.00 m 547.28 633.00 l S Q
+BT /F1 9.25 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 619.75 Tm (Computer Engineer graduated from the Polytechnic University of Valencia with specialization in Artificial Intelligence and) Tj ET
+BT /F1 9.25 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 606.50 Tm (Machine Learning. Professional experience developing and validating AI agents, building QA automation, and working) Tj ET
+BT /F1 9.25 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 593.25 Tm (with backend systems using Python, Spring Boot and Spring Batch. At Mercadona IT, he contributes to ATENEA, an AI) Tj ET
+BT /F1 9.25 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 580.00 Tm (agent platform, and IntegraT, a Spring Boot integration testing framework.) Tj ET
+BT /F1 8.65 Tf 0.060 0.490 0.520 rg 1 0 0 1 48.00 564.35 Tm (Core strengths: Research-to-production mindset - End-to-end ownership - Autonomous problem-solving - Cross-disciplinary) Tj ET
+BT /F1 8.65 Tf 0.060 0.490 0.520 rg 1 0 0 1 48.00 552.15 Tm (collaboration - International team communication - Fast ramp-up & self-directed learning) Tj ET
+BT /F2 10.00 Tf 0.080 0.160 0.270 rg 1 0 0 1 48.00 526.60 Tm (PROFESSIONAL EXPERIENCE) Tj ET
+q 1.35 w 0.060 0.490 0.520 RG 48.00 518.60 m 547.28 518.60 l S Q
+BT /F2 10.40 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 503.10 Tm (QA & AI Engineer) Tj ET
+BT /F1 8.50 Tf 0.350 0.390 0.440 rg 1 0 0 1 476.14 503.10 Tm (Jul. 2025 - Present) Tj ET
+BT /F1 9.00 Tf 0.060 0.490 0.520 rg 1 0 0 1 48.00 488.60 Tm (Mercadona IT) Tj ET
+BT /F1 9.10 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 471.50 Tm (Contributes to two internal projects at Mercadona IT: ATENEA, an AI agent platform built with Google ADK, LiteLLM and) Tj ET
+BT /F1 9.10 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 458.60 Tm (Claude, and IntegraT, a Spring Boot integration testing framework. Validates AI agents and develops agents for QA tasks,) Tj ET
+BT /F1 9.10 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 445.70 Tm (including generating tests from user stories and automating test cases. Explores access control for skills and MCP server) Tj ET
+BT /F1 9.10 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 432.80 Tm (scoping in subagent definitions through an agent definition protocol that extends MCP. Also works on automated test data) Tj ET
+BT /F1 9.10 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 419.90 Tm (management, backend integration tests and quality analysis with SonarQube.) Tj ET
+BT /F1 8.45 Tf 0.350 0.390 0.440 rg 1 0 0 1 48.00 407.65 Tm (Technologies: Python - Spring Boot & Spring Batch - ATENEA - Google ADK - LiteLLM - Claude - AI Agents for QA - MCP -) Tj ET
+BT /F1 8.45 Tf 0.350 0.390 0.440 rg 1 0 0 1 48.00 395.85 Tm (Subagent Scoping - User Story to Test Generation - Test Automation - IntegraT - Integration Tests - Mutant Testing - SonarQube) Tj ET
+BT /F2 10.40 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 371.00 Tm (Backend AI Engineer) Tj ET
+BT /F1 8.50 Tf 0.350 0.390 0.440 rg 1 0 0 1 465.94 371.00 Tm (Oct. 2024 - Jun. 2025) Tj ET
+BT /F1 9.00 Tf 0.060 0.490 0.520 rg 1 0 0 1 48.00 356.50 Tm (Urobora SL \(AI Startup\)) Tj ET
+BT /F1 9.10 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 339.40 Tm (Developed core AI infrastructure for an early-stage startup: autonomous agents for task automation, RAG systems for) Tj ET
+BT /F1 9.10 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 326.50 Tm (enterprise knowledge management, and microservices architecture on GCP/Kubernetes. Worked end-to-end from research) Tj ET
+BT /F1 9.10 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 313.60 Tm (to production deployment.) Tj ET
+BT /F1 8.45 Tf 0.350 0.390 0.440 rg 1 0 0 1 48.00 301.35 Tm (Technologies: Python - FastAPI - LLMs & RAG - GCP) Tj ET
+BT /F2 10.00 Tf 0.080 0.160 0.270 rg 1 0 0 1 48.00 276.00 Tm (EDUCATION) Tj ET
+q 1.35 w 0.060 0.490 0.520 RG 48.00 268.00 m 547.28 268.00 l S Q
+BT /F2 10.40 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 252.50 Tm (Bachelor's Degree in Computer Engineering) Tj ET
+BT /F1 8.50 Tf 0.350 0.390 0.440 rg 1 0 0 1 507.05 252.50 Tm (2021-2025) Tj ET
+BT /F1 9.00 Tf 0.060 0.490 0.520 rg 1 0 0 1 48.00 238.00 Tm (Polytechnic University of Valencia \(UPV\)) Tj ET
+BT /F1 9.00 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 221.00 Tm (Specialization in Artificial Intelligence and Machine Learning. Training in algorithms, data structures, software architectures,) Tj ET
+BT /F1 9.00 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 208.30 Tm (and machine learning systems.) Tj ET
+BT /F2 10.40 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 185.10 Tm (Erasmus in Computer Science) Tj ET
+BT /F1 8.50 Tf 0.350 0.390 0.440 rg 1 0 0 1 488.94 185.10 Tm (6 months, 2024) Tj ET
+BT /F1 9.00 Tf 0.060 0.490 0.520 rg 1 0 0 1 48.00 170.60 Tm (Technical University of Munich \(TUM\)) Tj ET
+BT /F1 9.00 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 153.60 Tm (International exchange program focused on AI and robotics. Participation in applied research projects on implicit neural) Tj ET
+BT /F1 9.00 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 140.90 Tm (models.) Tj ET
+BT /F2 10.40 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 117.70 Tm (Akademia Bankinter) Tj ET
+BT /F1 8.50 Tf 0.350 0.390 0.440 rg 1 0 0 1 528.58 117.70 Tm (2023) Tj ET
+BT /F1 9.00 Tf 0.060 0.490 0.520 rg 1 0 0 1 48.00 103.20 Tm (Bankinter Innovation Foundation) Tj ET
+BT /F1 9.00 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 86.20 Tm (Training program in innovation and technological entrepreneurship. Development of leadership skills and management of) Tj ET
+BT /F1 9.00 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 73.50 Tm (innovative projects.) Tj ET
+q 0.65 w 0.880 0.900 0.920 RG 48.00 39.00 m 547.28 39.00 l S Q
+BT /F1 7.30 Tf 0.350 0.390 0.440 rg 1 0 0 1 369.81 27.00 Tm (Carlos Hernández Martínez  -  Curriculum Vitae  |  1 / 2) Tj ET
+endstream
+endobj
+9 0 obj
+<< /Length 5424 >>
+stream
+q 0.060 0.490 0.520 rg 0.00 833.89 595.28 8.00 re f Q
+BT /F2 10.00 Tf 0.080 0.160 0.270 rg 1 0 0 1 48.00 811.89 Tm (Carlos Hernández Martínez) Tj ET
+BT /F1 7.20 Tf 0.350 0.390 0.440 rg 1 0 0 1 472.28 811.89 Tm (CURRICULUM VITAE) Tj ET
+q 0.80 w 0.880 0.900 0.920 RG 48.00 801.89 m 547.28 801.89 l S Q
+BT /F2 10.40 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 776.50 Tm (Diploma in Social Innovation) Tj ET
+BT /F1 8.50 Tf 0.350 0.390 0.440 rg 1 0 0 1 507.05 776.50 Tm (2019-2020) Tj ET
+BT /F1 9.00 Tf 0.060 0.490 0.520 rg 1 0 0 1 48.00 762.00 Tm (CEU San Pablo Valencia) Tj ET
+BT /F1 9.00 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 745.00 Tm (Training in social innovation and corporate responsibility in collaboration with Edwards Lifesciences.) Tj ET
+BT /F2 10.00 Tf 0.080 0.160 0.270 rg 1 0 0 1 48.00 719.30 Tm (SKILLS) Tj ET
+q 1.35 w 0.060 0.490 0.520 RG 48.00 711.30 m 547.28 711.30 l S Q
+BT /F2 9.00 Tf 0.080 0.160 0.270 rg 1 0 0 1 48.00 697.30 Tm (Backend & Core Engineering) Tj ET
+BT /F1 8.75 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 684.55 Tm (Python - Java - Spring Boot - Spring Batch) Tj ET
+BT /F2 9.00 Tf 0.080 0.160 0.270 rg 1 0 0 1 48.00 668.20 Tm (Artificial Intelligence) Tj ET
+BT /F1 8.75 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 655.45 Tm (AI Agents Development - Autonomous Agents Validation - Google ADK - LiteLLM - Claude - Model Context Protocol \(MCP\) -) Tj ET
+BT /F1 8.75 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 643.35 Tm (PyTorch - TensorFlow) Tj ET
+BT /F2 9.00 Tf 0.080 0.160 0.270 rg 1 0 0 1 48.00 627.00 Tm (QA & Software Quality) Tj ET
+BT /F1 8.75 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 614.25 Tm (Integration FWK \(Spring Boot\) - IntegraT - AI QA Automation - User Story to Test Generation - Mutant Testing - SonarQube -) Tj ET
+BT /F1 8.75 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 602.15 Tm (Playwright - Postman) Tj ET
+BT /F2 9.00 Tf 0.080 0.160 0.270 rg 1 0 0 1 48.00 585.80 Tm (DevOps & Cloud) Tj ET
+BT /F1 8.75 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 573.05 Tm (Google Cloud - CI/CD \(GitHub Actions, Jenkins, CloudBees\) - Spinnaker) Tj ET
+BT /F2 9.00 Tf 0.080 0.160 0.270 rg 1 0 0 1 48.00 556.70 Tm (Professional competencies) Tj ET
+BT /F1 8.80 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 543.90 Tm (- Technical Leadership & Mentoring) Tj ET
+BT /F1 8.80 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 531.90 Tm (- Strategic Product Vision) Tj ET
+BT /F1 8.80 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 519.90 Tm (- Cross-functional Collaboration) Tj ET
+BT /F1 8.80 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 507.90 Tm (- Analytical Thinking & Complex Problem Solving) Tj ET
+BT /F1 8.80 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 495.90 Tm (- Adaptability in Agile & Startup Environments) Tj ET
+BT /F1 8.80 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 483.90 Tm (- International Technical Communication) Tj ET
+BT /F2 10.00 Tf 0.080 0.160 0.270 rg 1 0 0 1 48.00 458.70 Tm (PROJECTS) Tj ET
+q 1.35 w 0.060 0.490 0.520 RG 48.00 450.70 m 547.28 450.70 l S Q
+BT /F2 10.00 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 435.20 Tm (Medical Diagnosis System with Deep Learning - Bachelor's Thesis) Tj ET
+BT /F1 9.00 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 420.70 Tm (Bachelor's thesis project developing an automatic classification system for knee osteoarthritis using medical radiographs.) Tj ET
+BT /F1 9.00 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 408.00 Tm (Implementation of CNN architectures \(ResNet, EfficientNet\) with PyTorch and TensorFlow, achieving 80% accuracy in binary) Tj ET
+BT /F1 9.00 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 395.30 Tm (classification. Application of fine-tuning techniques, data augmentation, and cross-domain validation. Focus on real clinical) Tj ET
+BT /F1 9.00 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 382.60 Tm (utility and scalability of the assisted diagnosis system.) Tj ET
+BT /F1 8.45 Tf 0.060 0.490 0.520 rg 1 0 0 1 48.00 370.45 Tm (Tags: Python - PyTorch - TensorFlow - Computer Vision - Healthcare AI) Tj ET
+BT /F1 8.35 Tf 0.350 0.390 0.440 rg 1 0 0 1 48.00 358.75 Tm (Links: https://github.com/Tempus23/Radiography_TFG) Tj ET
+BT /F2 10.00 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 333.90 Tm (Neural Implicit Models for Robotics - TUM Research) Tj ET
+BT /F1 9.00 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 319.40 Tm (Collaborative research at the Technical University of Munich \(TUM\) with KUKA Robotics. Development of implicit neural) Tj ET
+BT /F1 9.00 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 306.70 Tm (models for real-time collision detection in robotic manipulators. PyTorch implementation of swept volume models and) Tj ET
+BT /F1 9.00 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 294.00 Tm (optimization for efficient inference. Contribution to research paper at the intersection of Deep Learning and industrial robotics.) Tj ET
+BT /F1 8.45 Tf 0.060 0.490 0.520 rg 1 0 0 1 48.00 281.85 Tm (Tags: Python - PyTorch - Robotics - Research - Neural Networks) Tj ET
+BT /F1 8.35 Tf 0.350 0.390 0.440 rg 1 0 0 1 48.00 270.15 Tm (Links: https://github.com/Amrsaeed/FastCollisionDetection) Tj ET
+BT /F2 10.00 Tf 0.080 0.160 0.270 rg 1 0 0 1 48.00 244.80 Tm (LANGUAGES) Tj ET
+q 1.35 w 0.060 0.490 0.520 RG 48.00 236.80 m 547.28 236.80 l S Q
+BT /F1 9.10 Tf 0.120 0.150 0.190 rg 1 0 0 1 48.00 223.70 Tm (Spanish: Native - English: B2/C1 \(Cambridge Certificate\)) Tj ET
+q 0.65 w 0.880 0.900 0.920 RG 48.00 39.00 m 547.28 39.00 l S Q
+BT /F1 7.30 Tf 0.350 0.390 0.440 rg 1 0 0 1 369.81 27.00 Tm (Carlos Hernández Martínez  -  Curriculum Vitae  |  2 / 2) Tj ET
+endstream
+endobj
+10 0 obj
+
+endobj
+xref
+0 11
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000127 00000 n 
+0000000224 00000 n 
+0000000326 00000 n 
+0000000431 00000 n 
+0000000583 00000 n 
+0000000735 00000 n 
+0000007271 00000 n 
+0000012746 00000 n 
+trailer
+<< /Size 11 /Root 1 0 R /ID [<7668F32E37400B2A807A8D3EC64A8C29><7668F32E37400B2A807A8D3EC64A8C29>] >>
+startxref
+12763
+%%EOF

--- a/scripts/generate_cv_pdf.py
+++ b/scripts/generate_cv_pdf.py
@@ -1,0 +1,695 @@
+#!/usr/bin/env python3
+"""Generate a deterministic, one-column PDF CV from the English CV JSON.
+
+The generator intentionally uses only Python's standard library and the PDF
+Base-14 Helvetica fonts.  No dates, random values, or external assets are put
+in the document, so running it with the same JSON produces the same bytes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+import unicodedata
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+
+PAGE_WIDTH = 595.28  # A4, points
+PAGE_HEIGHT = 841.89
+LEFT = 48.0
+RIGHT = 48.0
+BODY_WIDTH = PAGE_WIDTH - LEFT - RIGHT
+BOTTOM = 54.0
+FIRST_PAGE_TOP = 654.0
+OTHER_PAGE_TOP = 788.0
+
+NAVY = (0.08, 0.16, 0.27)
+TEAL = (0.06, 0.49, 0.52)
+DARK = (0.12, 0.15, 0.19)
+MUTED = (0.35, 0.39, 0.44)
+LIGHT = (0.88, 0.90, 0.92)
+
+# A compact approximation of Helvetica's WinAnsi character widths.  Exact
+# font metrics are not required for the layout, but using real-ish widths
+# makes wrapping stable and avoids clipping long headings and URLs.
+HELVETICA_WIDTHS = {
+    " ": 0.278,
+    "!": 0.278,
+    '"': 0.355,
+    "#": 0.556,
+    "$": 0.556,
+    "%": 0.889,
+    "&": 0.667,
+    "'": 0.191,
+    "(": 0.333,
+    ")": 0.333,
+    "*": 0.389,
+    "+": 0.584,
+    ",": 0.278,
+    "-": 0.333,
+    ".": 0.278,
+    "/": 0.278,
+    ":": 0.278,
+    ";": 0.278,
+    "<": 0.584,
+    "=": 0.584,
+    ">": 0.584,
+    "?": 0.556,
+    "@": 1.015,
+    "[": 0.278,
+    "\\": 0.278,
+    "]": 0.278,
+    "^": 0.469,
+    "_": 0.556,
+    "`": 0.333,
+    "{": 0.334,
+    "|": 0.260,
+    "}": 0.334,
+    "~": 0.584,
+}
+for _letter in "abcdefghijklmnopqrstuvwxyz":
+    HELVETICA_WIDTHS[_letter] = {
+        "a": 0.556,
+        "b": 0.556,
+        "c": 0.500,
+        "d": 0.556,
+        "e": 0.556,
+        "f": 0.278,
+        "g": 0.556,
+        "h": 0.556,
+        "i": 0.222,
+        "j": 0.222,
+        "k": 0.500,
+        "l": 0.222,
+        "m": 0.833,
+        "n": 0.556,
+        "o": 0.556,
+        "p": 0.556,
+        "q": 0.556,
+        "r": 0.333,
+        "s": 0.500,
+        "t": 0.278,
+        "u": 0.556,
+        "v": 0.500,
+        "w": 0.722,
+        "x": 0.500,
+        "y": 0.500,
+        "z": 0.500,
+    }[_letter]
+for _letter in "ABCDEFGHIJKLMNOPQRSTUVWXYZ":
+    HELVETICA_WIDTHS[_letter] = {
+        "A": 0.667,
+        "B": 0.667,
+        "C": 0.722,
+        "D": 0.722,
+        "E": 0.667,
+        "F": 0.611,
+        "G": 0.778,
+        "H": 0.722,
+        "I": 0.278,
+        "J": 0.500,
+        "K": 0.667,
+        "L": 0.556,
+        "M": 0.833,
+        "N": 0.722,
+        "O": 0.778,
+        "P": 0.667,
+        "Q": 0.778,
+        "R": 0.722,
+        "S": 0.667,
+        "T": 0.611,
+        "U": 0.722,
+        "V": 0.667,
+        "W": 0.944,
+        "X": 0.667,
+        "Y": 0.667,
+        "Z": 0.611,
+    }[_letter]
+
+
+@dataclass(frozen=True)
+class Item:
+    kind: str
+    height: float
+    values: tuple[Any, ...]
+
+
+@dataclass(frozen=True)
+class PlacedItem:
+    item: Item
+    top: float
+
+
+def text_width(text: str, size: float) -> float:
+    """Return a stable width estimate for a Base-14 Helvetica string."""
+    total = 0.0
+    for char in text:
+        if char in HELVETICA_WIDTHS:
+            factor = HELVETICA_WIDTHS[char]
+        else:
+            decomposed = unicodedata.normalize("NFKD", char)
+            base = decomposed[0] if decomposed else "?"
+            factor = HELVETICA_WIDTHS.get(base, 0.55)
+        total += factor * size
+    return total
+
+
+def safe_text(text: Any) -> str:
+    """Make input safe for WinAnsi while retaining common European accents."""
+    value = str(text)
+    replacements = {
+        "\u2018": "'",
+        "\u2019": "'",
+        "\u201c": '"',
+        "\u201d": '"',
+        "\u2013": "-",
+        "\u2014": "-",
+        "\u2022": "-",
+        "\u00a0": " ",
+    }
+    value = "".join(replacements.get(char, char) for char in value)
+    return value.encode("cp1252", errors="replace").decode("cp1252")
+
+
+def wrap_text(text: str, max_width: float, size: float) -> list[str]:
+    """Wrap text by measured width, splitting an unusually long token safely."""
+    normalized = safe_text(text).replace("\r\n", "\n").replace("\r", "\n")
+    result: list[str] = []
+    for paragraph in normalized.split("\n"):
+        words = paragraph.split()
+        if not words:
+            result.append("")
+            continue
+        line = ""
+        for word in words:
+            candidate = word if not line else f"{line} {word}"
+            if text_width(candidate, size) <= max_width:
+                line = candidate
+                continue
+            if line:
+                result.append(line)
+                line = ""
+            # URLs and other long tokens must not overflow the content column.
+            chunk = ""
+            for char in word:
+                candidate_chunk = chunk + char
+                if chunk and text_width(candidate_chunk, size) > max_width:
+                    result.append(chunk)
+                    chunk = char
+                else:
+                    chunk = candidate_chunk
+            line = chunk
+        if line:
+            result.append(line)
+    return result
+
+
+def rgb(color: tuple[float, float, float]) -> bytes:
+    return f"{color[0]:.3f} {color[1]:.3f} {color[2]:.3f}".encode("ascii")
+
+
+def pdf_string(value: str) -> bytes:
+    """Encode a text string as a PDF literal string using WinAnsi bytes."""
+    raw = safe_text(value).encode("cp1252")
+    escaped = bytearray()
+    for byte in raw:
+        if byte in (0x28, 0x29, 0x5c):  # (, ), backslash
+            escaped.extend((0x5C, byte))
+        elif byte == 0x0A:
+            escaped.extend(b"\\n")
+        elif byte == 0x0D:
+            escaped.extend(b"\\r")
+        else:
+            escaped.append(byte)
+    return b"(" + bytes(escaped) + b")"
+
+
+def draw_text(x: float, baseline: float, value: str, font: str, size: float, color: tuple[float, float, float]) -> bytes:
+    return b" ".join(
+        (
+            b"BT",
+            b"/" + font.encode("ascii") + f" {size:.2f} Tf".encode("ascii"),
+            rgb(color) + b" rg",
+            f"1 0 0 1 {x:.2f} {baseline:.2f} Tm".encode("ascii"),
+            pdf_string(value),
+            b"Tj",
+            b"ET",
+        )
+    )
+
+
+def draw_rule(x1: float, y: float, x2: float, color: tuple[float, float, float], width: float = 0.8) -> bytes:
+    return b" ".join(
+        (
+            b"q",
+            f"{width:.2f} w".encode("ascii"),
+            rgb(color) + b" RG",
+            f"{x1:.2f} {y:.2f} m {x2:.2f} {y:.2f} l S".encode("ascii"),
+            b"Q",
+        )
+    )
+
+
+def draw_rect(x: float, y: float, width: float, height: float, color: tuple[float, float, float]) -> bytes:
+    return b" ".join(
+        (
+            b"q",
+            rgb(color) + b" rg",
+            f"{x:.2f} {y:.2f} {width:.2f} {height:.2f} re f".encode("ascii"),
+            b"Q",
+        )
+    )
+
+
+class FlowLayout:
+    """A small page-flow engine that keeps all content inside the margins."""
+
+    def __init__(self) -> None:
+        self.pages: list[list[PlacedItem]] = [[]]
+        self.y = FIRST_PAGE_TOP
+
+    @property
+    def page_index(self) -> int:
+        return len(self.pages) - 1
+
+    def new_page(self) -> None:
+        self.pages.append([])
+        self.y = OTHER_PAGE_TOP
+
+    def place(self, item: Item, minimum_following: float = 0.0) -> None:
+        if self.pages[-1] and self.y - item.height - minimum_following < BOTTOM:
+            self.new_page()
+        self.pages[-1].append(PlacedItem(item, self.y))
+        self.y -= item.height
+
+    def section(self, title: str) -> None:
+        # Keep a section heading with a useful amount of following content.
+        if self.pages[-1] and self.y - 25.0 - 30.0 < BOTTOM:
+            self.new_page()
+        self.place(Item("section", 25.0, (safe_text(title),)))
+
+    def spacer(self, height: float = 7.0) -> None:
+        self.place(Item("spacer", height, ()))
+
+    def paragraph(self, text: str, size: float = 9.25, leading: float = 13.25, color: tuple[float, float, float] = DARK, indent: float = 0.0) -> None:
+        for line in wrap_text(text, BODY_WIDTH - indent, size):
+            self.place(Item("text", leading, (line, LEFT + indent, size, color, "F1")))
+
+    def labeled_lines(
+        self,
+        label: str,
+        values: Iterable[str],
+        size: float = 8.65,
+        leading: float = 12.2,
+        color: tuple[float, float, float] = MUTED,
+    ) -> None:
+        label_text = safe_text(label)
+        values_text = " - ".join(safe_text(value) for value in values)
+        joined = f"{label_text}: {values_text}" if label_text else values_text
+        lines = wrap_text(joined, BODY_WIDTH, size)
+        for line in lines:
+            self.place(Item("text", leading, (line, LEFT, size, color, "F1")))
+
+    def entry_header(self, title: str, organization: str, date: str) -> None:
+        title_size = 10.4
+        date_size = 8.5
+        date_text = safe_text(date)
+        date_width = text_width(date_text, date_size)
+        title_width = BODY_WIDTH - date_width - 14.0
+        title_lines = wrap_text(title, title_width, title_size)
+        organization_lines = wrap_text(organization, BODY_WIDTH, 9.0)
+        height = 16.0 * len(title_lines) + 13.0 * len(organization_lines) + 5.0
+        self.place(Item("entry_header", height, (tuple(title_lines), tuple(organization_lines), date_text, title_size, date_size)))
+
+    def bullet_lines(self, values: Iterable[str], size: float = 9.0, leading: float = 12.9) -> None:
+        for value in values:
+            lines = wrap_text(value, BODY_WIDTH - 14.0, size)
+            for index, line in enumerate(lines):
+                prefix = "- " if index == 0 else "  "
+                self.place(Item("text", leading, (prefix + line, LEFT, size, DARK, "F1")))
+
+
+def build_layout(data: dict[str, Any]) -> FlowLayout:
+    layout = FlowLayout()
+    basic = data.get("basic_info", {})
+    about = data.get("about_me", {})
+
+    layout.section("SUMMARY")
+    for paragraph in about.get("description_paragraphs", []):
+        layout.paragraph(paragraph)
+        layout.spacer(3.0)
+    attributes = about.get("attributes", [])
+    if attributes:
+        layout.labeled_lines("Core strengths", attributes, size=8.65, color=TEAL)
+    layout.spacer(9.0)
+
+    experience = data.get("professional_experience", [])
+    if experience:
+        layout.section("PROFESSIONAL EXPERIENCE")
+        for index, job in enumerate(experience):
+            layout.entry_header(job.get("title", ""), job.get("company", ""), job.get("date", ""))
+            layout.paragraph(job.get("description", ""), size=9.1, leading=12.9)
+            keywords = job.get("keywords", [])
+            if keywords:
+                layout.labeled_lines("Technologies", keywords, size=8.45, leading=11.8, color=MUTED)
+            if index != len(experience) - 1:
+                layout.spacer(10.0)
+        layout.spacer(9.0)
+
+    education = data.get("academic_formation", [])
+    if education:
+        layout.section("EDUCATION")
+        for index, item in enumerate(education):
+            layout.entry_header(item.get("title", ""), item.get("company", ""), item.get("date", ""))
+            layout.paragraph(item.get("description", ""), size=9.0, leading=12.7)
+            if index != len(education) - 1:
+                layout.spacer(8.0)
+        layout.spacer(9.0)
+
+    skills = data.get("skills", {})
+    technical = skills.get("technical", [])
+    competencies = skills.get("competencies", [])
+    if technical or competencies:
+        layout.section("SKILLS")
+        for category in technical:
+            category_name = safe_text(category.get("category", ""))
+            layout.place(Item("skill_category", 14.0, (category_name,)))
+            items = category.get("items", [])
+            if items:
+                layout.labeled_lines("", items, size=8.75, leading=12.1, color=DARK)
+            layout.spacer(3.0)
+        if competencies:
+            layout.place(Item("skill_category", 14.0, ("Professional competencies",)))
+            layout.bullet_lines(competencies, size=8.8, leading=12.0)
+        layout.spacer(9.0)
+
+    projects = data.get("projects", [])
+    if projects:
+        layout.section("PROJECTS")
+        for index, project in enumerate(projects):
+            layout.place(Item("project_title", 17.0, (safe_text(project.get("title", "")),)))
+            layout.paragraph(project.get("description", ""), size=9.0, leading=12.7)
+            tags = project.get("tags", [])
+            if tags:
+                layout.labeled_lines("Tags", tags, size=8.45, leading=11.8, color=TEAL)
+            links = [link for link in (project.get("link", ""), project.get("github", "")) if link]
+            if links:
+                layout.labeled_lines("Links", links, size=8.35, leading=11.7, color=MUTED)
+            if index != len(projects) - 1:
+                layout.spacer(10.0)
+        layout.spacer(9.0)
+
+    languages = data.get("languages", [])
+    if languages:
+        layout.section("LANGUAGES")
+        language_text = " - ".join(f"{safe_text(item.get('name', ''))}: {safe_text(item.get('level', ''))}" for item in languages)
+        for line in wrap_text(language_text, BODY_WIDTH, 9.1):
+            layout.place(Item("text", 13.0, (line, LEFT, 9.1, DARK, "F1")))
+
+    # The contact block is deliberately read from the same canonical JSON as
+    # the body, rather than being duplicated in this script.
+    _ = basic
+    return layout
+
+
+def render_page(items: list[PlacedItem], page_number: int, page_count: int, data: dict[str, Any]) -> bytes:
+    commands: list[bytes] = []
+    basic = data.get("basic_info", {})
+    name = safe_text(basic.get("name", ""))
+
+    # Header is present only on the first page.  The continuation pages get a
+    # restrained running bar so the document still feels like one CV.
+    if page_number == 1:
+        commands.append(draw_rect(0, PAGE_HEIGHT - 15.0, PAGE_WIDTH, 15.0, NAVY))
+        commands.append(draw_text(LEFT, 786.0, name, "F2", 24.0, NAVY))
+        commands.append(draw_text(LEFT, 758.0, safe_text(basic.get("role", "")), "F2", 11.5, TEAL))
+        tagline = basic.get("tagline", "")
+        if tagline:
+            commands.append(draw_text(LEFT, 739.0, safe_text(tagline), "F3", 9.3, MUTED))
+
+        emails = [safe_text(email) for email in basic.get("emails", []) if email]
+        contact_first = "  |  ".join(emails)
+        contact_second = "  |  ".join(
+            part
+            for part in (
+                f"LinkedIn: {safe_text(basic.get('linkedin', ''))}" if basic.get("linkedin") else "",
+                f"GitHub: {safe_text(basic.get('github', ''))}" if basic.get("github") else "",
+                safe_text(basic.get("location", "")),
+            )
+            if part
+        )
+        contact_lines = wrap_text(contact_first, BODY_WIDTH, 8.25) + wrap_text(contact_second, BODY_WIDTH, 8.25)
+        contact_y = 716.0
+        for line in contact_lines[:3]:
+            commands.append(draw_text(LEFT, contact_y, line, "F1", 8.25, MUTED))
+            contact_y -= 12.0
+        commands.append(draw_rule(LEFT, 681.0, PAGE_WIDTH - RIGHT, LIGHT, 1.0))
+    else:
+        commands.append(draw_rect(0, PAGE_HEIGHT - 8.0, PAGE_WIDTH, 8.0, TEAL))
+        commands.append(draw_text(LEFT, PAGE_HEIGHT - 30.0, name, "F2", 10.0, NAVY))
+        commands.append(draw_text(PAGE_WIDTH - RIGHT - 75.0, PAGE_HEIGHT - 30.0, "CURRICULUM VITAE", "F1", 7.2, MUTED))
+        commands.append(draw_rule(LEFT, PAGE_HEIGHT - 40.0, PAGE_WIDTH - RIGHT, LIGHT, 0.8))
+
+    for placed in items:
+        item = placed.item
+        top = placed.top
+        if item.kind == "section":
+            title = item.values[0]
+            commands.append(draw_text(LEFT, top - 13.0, title, "F2", 10.0, NAVY))
+            commands.append(draw_rule(LEFT, top - 21.0, PAGE_WIDTH - RIGHT, TEAL, 1.35))
+        elif item.kind == "text":
+            value, x, size, color, font = item.values
+            commands.append(draw_text(float(x), top - float(size), value, font, float(size), color))
+        elif item.kind == "entry_header":
+            title_lines, organization_lines, date, title_size, date_size = item.values
+            for index, line in enumerate(title_lines):
+                baseline = top - 11.5 - (index * 16.0)
+                commands.append(draw_text(LEFT, baseline, line, "F2", title_size, DARK))
+                if index == 0 and date:
+                    date_x = PAGE_WIDTH - RIGHT - text_width(date, date_size)
+                    commands.append(draw_text(date_x, baseline, date, "F1", date_size, MUTED))
+            organization_top = top - (16.0 * len(title_lines))
+            for index, line in enumerate(organization_lines):
+                commands.append(draw_text(LEFT, organization_top - 10.0 - (index * 13.0), line, "F1", 9.0, TEAL))
+        elif item.kind == "skill_category":
+            commands.append(draw_text(LEFT, top - 10.0, item.values[0], "F2", 9.0, NAVY))
+        elif item.kind == "project_title":
+            commands.append(draw_text(LEFT, top - 11.5, item.values[0], "F2", 10.0, DARK))
+
+    footer = f"{name}  -  Curriculum Vitae  |  {page_number} / {page_count}"
+    commands.append(draw_rule(LEFT, 39.0, PAGE_WIDTH - RIGHT, LIGHT, 0.65))
+    footer_width = text_width(footer, 7.3)
+    commands.append(draw_text(PAGE_WIDTH - RIGHT - footer_width, 27.0, footer, "F1", 7.3, MUTED))
+    return b"\n".join(commands) + b"\n"
+
+
+def pdf_object(content: bytes) -> bytes:
+    return content
+
+
+def build_pdf(data: dict[str, Any], layout: FlowLayout) -> bytes:
+    page_count = len(layout.pages)
+    streams = [render_page(items, index + 1, page_count, data) for index, items in enumerate(layout.pages)]
+
+    # Object numbering is fixed: catalog, page tree, three fonts, then each
+    # page followed by its content stream.  This is part of the determinism.
+    catalog_id = 1
+    pages_id = 2
+    font_regular_id = 3
+    font_bold_id = 4
+    font_italic_id = 5
+    first_page_id = 6
+    first_stream_id = first_page_id + page_count
+    objects: list[bytes] = [b""] * (first_stream_id + page_count)
+    objects[catalog_id - 1] = b"<< /Type /Catalog /Pages 2 0 R >>"
+    page_ids = [first_page_id + index for index in range(page_count)]
+    kids = " ".join(f"{page_id} 0 R" for page_id in page_ids)
+    objects[pages_id - 1] = f"<< /Type /Pages /Kids [{kids}] /Count {page_count} >>".encode("ascii")
+    objects[font_regular_id - 1] = b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>"
+    objects[font_bold_id - 1] = b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding >>"
+    objects[font_italic_id - 1] = b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding >>"
+
+    for index, stream in enumerate(streams):
+        page_id = page_ids[index]
+        stream_id = first_stream_id + index
+        objects[page_id - 1] = (
+            f"<< /Type /Page /Parent {pages_id} 0 R /MediaBox [0 0 {PAGE_WIDTH:.2f} {PAGE_HEIGHT:.2f}] "
+            f"/Resources << /Font << /F1 {font_regular_id} 0 R /F2 {font_bold_id} 0 R /F3 {font_italic_id} 0 R >> >> "
+            f"/Contents {stream_id} 0 R >>"
+        ).encode("ascii")
+        objects[stream_id - 1] = b"<< /Length " + str(len(stream)).encode("ascii") + b" >>\nstream\n" + stream + b"endstream"
+
+    header = b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n"
+    document_body = bytearray(header)
+    offsets = [0]
+    for object_number, content in enumerate(objects, start=1):
+        offsets.append(len(document_body))
+        document_body.extend(f"{object_number} 0 obj\n".encode("ascii"))
+        document_body.extend(pdf_object(content))
+        document_body.extend(b"\nendobj\n")
+
+    xref_offset = len(document_body)
+    document_body.extend(f"xref\n0 {len(objects) + 1}\n".encode("ascii"))
+    document_body.extend(b"0000000000 65535 f \n")
+    for offset in offsets[1:]:
+        document_body.extend(f"{offset:010d} 00000 n \n".encode("ascii"))
+
+    # The ID is content-derived and therefore stable, without introducing a
+    # timestamp or random value into an otherwise reproducible artifact.
+    file_id = hashlib.md5(bytes(document_body), usedforsecurity=False).hexdigest().upper().encode("ascii")
+    document_body.extend(
+        b"trailer\n"
+        + f"<< /Size {len(objects) + 1} /Root {catalog_id} 0 R /ID [<".encode("ascii")
+        + file_id
+        + b"><"
+        + file_id
+        + b">] >>\n"
+        + f"startxref\n{xref_offset}\n%%EOF\n".encode("ascii")
+    )
+    return bytes(document_body)
+
+
+def extract_literal_strings(pdf: bytes) -> list[str]:
+    """Extract literal strings from uncompressed content streams for checks."""
+    strings: list[str] = []
+    for match in re.finditer(rb"stream\r?\n(.*?)\r?\nendstream", pdf, flags=re.DOTALL):
+        stream = match.group(1)
+        index = 0
+        while index < len(stream):
+            if stream[index] != 0x28:  # '('
+                index += 1
+                continue
+            index += 1
+            depth = 1
+            value = bytearray()
+            while index < len(stream) and depth:
+                byte = stream[index]
+                index += 1
+                if byte == 0x5C:  # backslash escape
+                    if index >= len(stream):
+                        break
+                    escaped = stream[index]
+                    index += 1
+                    simple = {ord("n"): 10, ord("r"): 13, ord("t"): 9, ord("b"): 8, ord("f"): 12}
+                    if escaped in simple:
+                        value.append(simple[escaped])
+                    elif 48 <= escaped <= 55:
+                        digits = bytes([escaped])
+                        for _ in range(2):
+                            if index < len(stream) and 48 <= stream[index] <= 55:
+                                digits += bytes([stream[index]])
+                                index += 1
+                            else:
+                                break
+                        value.append(int(digits, 8))
+                    else:
+                        value.append(escaped)
+                elif byte == 0x28:
+                    depth += 1
+                    value.append(byte)
+                elif byte == 0x29:
+                    depth -= 1
+                    if depth:
+                        value.append(byte)
+                else:
+                    value.append(byte)
+            strings.append(bytes(value).decode("cp1252", errors="replace"))
+    return strings
+
+
+def validate_pdf(path: Path, expected: Iterable[str], expected_pdf: bytes) -> tuple[bool, str]:
+    if not path.is_file():
+        return False, f"missing artifact: {path}"
+    pdf = path.read_bytes()
+    if not pdf.startswith(b"%PDF-1.4") or b"%%EOF" not in pdf[-32:]:
+        return False, "invalid PDF header or EOF marker"
+    if b"xref\n" not in pdf or b"/Type /Catalog" not in pdf:
+        return False, "missing cross-reference table or catalog"
+    strings = extract_literal_strings(pdf)
+    extracted = "\n".join(strings)
+    missing = [value for value in expected if value not in extracted]
+    if missing:
+        return False, "missing expected text: " + ", ".join(missing)
+    page_count = len(re.findall(rb"/Type /Page /Parent", pdf))
+    if page_count < 1:
+        return False, "PDF contains no page objects"
+    actual_hash = hashlib.sha256(pdf).hexdigest()
+    expected_hash = hashlib.sha256(expected_pdf).hexdigest()
+    if actual_hash != expected_hash:
+        return False, f"artifact does not match current generated PDF (sha256 {actual_hash} != {expected_hash})"
+    return True, f"valid PDF; {page_count} page(s); {len(pdf)} bytes; expected text present; sha256 {actual_hash} matches current data"
+
+
+def load_data(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        value = json.load(handle)
+    if not isinstance(value, dict):
+        raise ValueError("CV data must be a JSON object")
+    return value
+
+
+def generate(data_path: Path, output_path: Path) -> tuple[Path, int, int]:
+    data = load_data(data_path)
+    layout = build_layout(data)
+    pdf = build_pdf(data, layout)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_bytes(pdf)
+    return output_path, len(layout.pages), len(pdf)
+
+
+def main(argv: list[str] | None = None) -> int:
+    repository = Path(__file__).resolve().parents[1]
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--data", type=Path, default=repository / "src/data/cv_data.json")
+    parser.add_argument("--output", type=Path, default=repository / "public/carlos-hernandez-martinez-cv.pdf")
+    parser.add_argument("--validate", action="store_true", help="validate the existing output instead of generating it")
+    args = parser.parse_args(argv)
+    data_path = args.data.resolve()
+    output_path = args.output.resolve()
+
+    try:
+        if args.validate:
+            data = load_data(data_path)
+            basic = data.get("basic_info", {})
+            expected = (
+                safe_text(basic.get("name", "")),
+                "SUMMARY",
+                "PROFESSIONAL EXPERIENCE",
+                "EDUCATION",
+                "SKILLS",
+                "PROJECTS",
+                "LANGUAGES",
+                safe_text(basic.get("role", "")),
+            )
+            expected_pdf = build_pdf(data, build_layout(data))
+            ok, message = validate_pdf(output_path, expected, expected_pdf)
+            print(f"{message}: {output_path}")
+            return 0 if ok else 1
+
+        path, page_count, byte_count = generate(data_path, output_path)
+        print(f"Generated {path} ({page_count} page(s), {byte_count} bytes)")
+        return 0
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "build_layout",
+    "build_pdf",
+    "extract_literal_strings",
+    "generate",
+    "validate_pdf",
+]
+
+
+# End of file.

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -35,7 +35,7 @@ const navItems = [
   class="fixed top-0 z-10 flex items-center justify-center w-full mx-auto mt-2"
 >
   <nav
-    class="flex px-3 text-sm font-medium rounded-full text-gray-600 dark:text-gray-200 justify-center items-center"
+    class="flex max-w-[calc(100%_-_1rem)] flex-wrap px-3 text-sm font-medium rounded-full text-gray-600 dark:text-gray-200 justify-center items-center gap-y-1"
   >
     {
       navItems.map((link) => (
@@ -48,6 +48,24 @@ const navItems = [
         </a>
       ))
     }
+    <a
+      class="relative ml-1 inline-flex items-center justify-center gap-1.5 rounded-full bg-indigo-600 px-3 py-1.5 text-xs font-semibold text-white transition-colors duration-200 hover:bg-indigo-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:bg-indigo-500 dark:hover:bg-indigo-400 dark:focus-visible:ring-indigo-400"
+      aria-label="Download CV"
+      href="/carlos-hernandez-martinez-cv.pdf"
+      download="Carlos-Hernandez-Martinez-CV.pdf"
+    >
+      <svg
+        aria-hidden="true"
+        class="size-3.5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke-width="1.8"
+        stroke="currentColor"
+      >
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v12m0 0 4-4m-4 4-4-4M5 21h14" />
+      </svg>
+      <span>Download CV</span>
+    </a>
     <ThemeToggle />
   </nav>
 </header>

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -35,7 +35,7 @@ const navItems = [
   class="fixed top-0 z-10 flex items-center justify-center w-full mx-auto mt-2"
 >
   <nav
-    class="flex max-w-[calc(100%_-_1rem)] flex-wrap px-3 text-sm font-medium rounded-full text-gray-600 dark:text-gray-200 justify-center items-center gap-y-1"
+    class="flex px-3 text-sm font-medium rounded-full text-gray-600 dark:text-gray-200 justify-center items-center"
   >
     {
       navItems.map((link) => (
@@ -48,24 +48,6 @@ const navItems = [
         </a>
       ))
     }
-    <a
-      class="relative ml-1 inline-flex items-center justify-center gap-1.5 rounded-full bg-indigo-600 px-3 py-1.5 text-xs font-semibold text-white transition-colors duration-200 hover:bg-indigo-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:bg-indigo-500 dark:hover:bg-indigo-400 dark:focus-visible:ring-indigo-400"
-      aria-label="Download CV"
-      href="/carlos-hernandez-martinez-cv.pdf"
-      download="Carlos-Hernandez-Martinez-CV.pdf"
-    >
-      <svg
-        aria-hidden="true"
-        class="size-3.5"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke-width="1.8"
-        stroke="currentColor"
-      >
-        <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v12m0 0 4-4m-4 4-4-4M5 21h14" />
-      </svg>
-      <span>Download CV</span>
-    </a>
     <ThemeToggle />
   </nav>
 </header>

--- a/src/components/sections/Hero.astro
+++ b/src/components/sections/Hero.astro
@@ -41,6 +41,24 @@ const personalImageAlt = basic_info.personal_image_alt;
   />
 
   <nav class="flex flex-wrap justify-center gap-3 mt-8">
+    <a
+      href="/carlos-hernandez-martinez-cv.pdf"
+      download="Carlos-Hernandez-Martinez-CV.pdf"
+      aria-label="Download CV"
+      class="inline-flex items-center justify-center gap-2 rounded-full bg-indigo-600 px-5 py-2 text-sm font-semibold text-white shadow-md shadow-indigo-500/25 transition-all duration-300 hover:bg-indigo-500 hover:shadow-lg hover:shadow-indigo-500/30 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:bg-indigo-500 dark:hover:bg-indigo-400 dark:focus-visible:ring-indigo-400"
+    >
+      <svg
+        aria-hidden="true"
+        class="size-4"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke-width="1.8"
+        stroke="currentColor"
+      >
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v12m0 0 4-4m-4 4-4-4M5 21h14" />
+      </svg>
+      <span>Download CV</span>
+    </a>
     <SocialPill href={`mailto:${basic_info.emails[0]}`}>
       <Mail class="size-4" />
       <span>Contact Me</span>


### PR DESCRIPTION
## Summary
- Add a professional downloadable CV generated from `src/data/cv_data.json`.
- Keep the single accessible Download CV action in the page hero only.
- Do not add a CV action to the fixed header.

## Verification
- `npm run generate:cv`
- `python3 scripts/generate_cv_pdf.py --validate`
- `env HOME=/tmp NODE_OPTIONS=--max-old-space-size=2048 npm run astro -- build`
- Visual browser checks at 390×844 and 1440×900: one hero download button, clean header, no horizontal overflow, no page errors.
- PDF and homepage served with HTTP 200.

Please review and approve; do not merge automatically.